### PR TITLE
Fix ACL error on S3 uploads

### DIFF
--- a/src/routes/caseRoutes.ts
+++ b/src/routes/caseRoutes.ts
@@ -1,19 +1,18 @@
 import { Router } from 'express';
-import AWS from 'aws-sdk';
 import multer from 'multer';
 import multerS3 from 'multer-s3';
 import checkLoggedIn  from '../middlewares/checkLoggedIn';
 import * as caseCtrl from '../controllers/caseController';
 import { S3Client } from '@aws-sdk/client-s3';
 
-AWS.config.update({ region: 'ap-northeast-1' });
-const s3 = new S3Client({ region: 'ap-northeast-1' });
+const s3 = new S3Client({ region: process.env.AWS_REGION });
 
 const upload = multer({
     storage: multerS3({
         s3,
-        bucket: 'images.rental.imallenlai.com',
-        acl: 'public-read',
+        bucket: process.env.S3_BUCKET_NAME!,
+        // The bucket enforces BucketOwnerEnforced; ACLs cannot be set.
+        // Configure bucket policies to manage public access if needed.
         contentType: multerS3.AUTO_CONTENT_TYPE,
         key: (_req, file, cb) => {
             const key = `cases/${Date.now()}-${Math.random().toString(36).slice(2)}-${file.originalname}`;


### PR DESCRIPTION
## Summary
- remove `acl` option when uploading to S3 because the bucket has ACLs disabled
- use environment variables for S3 region and bucket

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a39fc6ae0832db9efa9b304817bbf