### PR TITLE
Fix plaintiff ID property for case creation

### DIFF
--- a/src/controllers/caseController.ts
+++ b/src/controllers/caseController.ts
@@ -11,7 +11,7 @@ export const createCase = async (req: RequestWithUser, res: Response) => {
         )?.map((f) => `https://${f.bucket}.s3.amazonaws.com/${f.key}`) ?? [];
 
         const id = await caseService.createCase({
-            plaintiffId: req.user!.userId,
+            plaintiffId: req.user!.uid,
             defendantName,
             defendantPhone,
             defendantIdNo,
@@ -58,7 +58,7 @@ export const addComment = async (req: RequestWithUser, res: Response) => {
     try {
         await caseService.addComment(
             Number(req.params.id),
-      req.user!.userId,
+      req.user!.uid,
       req.body.content
         );
         return res.status(201).end();
@@ -73,7 +73,7 @@ export const toggleLike = async (req: RequestWithUser, res: Response) => {
     try {
         const liked = await caseService.toggleLike(
             Number(req.params.id),
-      req.user!.userId
+      req.user!.uid
         );
         return res.json({ liked });
     } catch (err) {

--- a/src/middlewares/checkLoggedIn.ts
+++ b/src/middlewares/checkLoggedIn.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import jwt, { JwtPayload } from 'jsonwebtoken';
 
 interface UserPayload extends JwtPayload {
+    uid: string;
     name: string;
     phone: string;
     email: string;


### PR DESCRIPTION
## Summary
- use uid from JWT token when creating cases or comments
- extend middleware user type with uid

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684a497d13bc832d83eda4f73df91f2d