### PR TITLE
Fix userId types in controllers

### DIFF
--- a/src/controllers/commentController.ts
+++ b/src/controllers/commentController.ts
@@ -4,7 +4,7 @@ import { RequestWithUser } from '../middlewares/checkLoggedIn';
 
 export default {
     async addComment(req: RequestWithUser, res: Response) {
-        const userId = req.user?.uid;
+        const userId = req.user!.uid;
         const { filesetId, content } = req.body;
         const comment = await commentService.createComment(userId, filesetId, content);
         res.status(201).json(comment);

--- a/src/controllers/likeController.ts
+++ b/src/controllers/likeController.ts
@@ -3,7 +3,7 @@ import { toggleLike, getLikeCount, getLikeStatus } from '../services/likeService
 import { RequestWithUser } from '../middlewares/checkLoggedIn';
 
 export const handleToggleLike = async (req: RequestWithUser, res: Response) => {
-    const userId = req.user?.uid;
+    const userId = req.user!.uid;
     const { filesetId } = req.params;
     try {
         const liked = await toggleLike(userId, filesetId);
@@ -24,7 +24,7 @@ export const handleGetLikeCount = async (req: Request, res: Response) => {
 };
 
 export const handleGetLikeStatus = async (req: RequestWithUser, res: Response) => {
-    const userId = req.user?.uid;
+    const userId = req.user!.uid;
     const filesetId = req.params.filesetId;
     const liked = await getLikeStatus(userId, filesetId);
     res.json({ liked });

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -10,7 +10,7 @@ export default {
 
     async createUser(req: RequestWithUser, res: Response) {
         
-        await updateUser(req.user?.uid, {
+        await updateUser(req.user!.uid, {
             ...req.body,
         });
         req.user = {...req.user, ...req.body};


### PR DESCRIPTION
## Summary
- ensure a defined user ID when creating comments and likes
- fix createUser to pass non-optional UID

## Testing
- `npm test`
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684a5dad0a80832db5bd86163ff9f851