### PR TITLE
Fix JSON parse error for imageUrls

### DIFF
--- a/src/controllers/caseController.ts
+++ b/src/controllers/caseController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { RequestWithUser } from '../middlewares/checkLoggedIn';
 import * as caseService from '../services/caseService';
+import { safeJsonParse } from '../utils/safeJsonParse';
 
 /** 建立新案例 */
 export const createCase = async (req: RequestWithUser, res: Response) => {
@@ -31,7 +32,7 @@ export const listCases = async (_req: Request, res: Response) => {
         const rows = await caseService.listCases();
         const data = rows.map((r) => ({
             ...r,
-            imageUrls: JSON.parse(r.imageUrls),
+            imageUrls: safeJsonParse<string[]>(r.imageUrls, []),
         }));
         return res.json(data);
     } catch (err) {

--- a/src/services/caseService.ts
+++ b/src/services/caseService.ts
@@ -1,4 +1,5 @@
 import { db } from '../db'; // 既有的 Knex 實例 (import knex({ ... }))
+import { safeJsonParse } from '../utils/safeJsonParse';
 
 /*********************************
  * 型別定義
@@ -70,7 +71,7 @@ export const getCaseDetail = async (id: number) => {
 
     return {
         ...caseRow,
-        imageUrls: JSON.parse(caseRow.imageUrls),
+        imageUrls: safeJsonParse<string[]>(caseRow.imageUrls, []),
         comments,
         likeCount: Number(likeCount || 0),
     };

--- a/src/utils/safeJsonParse.ts
+++ b/src/utils/safeJsonParse.ts
@@ -1,0 +1,8 @@
+export function safeJsonParse<T>(value: string | null | undefined, defaultValue: T): T {
+    if (!value) return defaultValue;
+    try {
+        return JSON.parse(value) as T;
+    } catch {
+        return defaultValue;
+    }
+}


### PR DESCRIPTION
## Summary
- avoid crashing when `imageUrls` is invalid JSON
- add a small util `safeJsonParse` and use it in case controller and service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a6332a5d0832d9993eb4c3b994cfe