### PR TITLE
Add SQL example for new fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ sudo apt install mysql-client mysql-server
                 -   defendant
             -   rent `int`
             -   jyear `string`
+        -   cases
+            -   id `auto`
+            -   plaintiffId `string`
+            -   title `string`
+            -   content `text`
+            -   defendantName `string`
+            -   defendantPhone `string`
+            -   defendantIdNo `string`
+            -   imageUrls `text`
+            -   createdAt `timestamp`
+            -   updatedAt `timestamp`
+
+### 新增欄位
+
+若 `cases` 表尚無 `title` 與 `content` 欄位，可執行下列 SQL 新增：
+
+```sql
+ALTER TABLE cases
+    ADD COLUMN title VARCHAR(255) NOT NULL AFTER plaintiffId,
+    ADD COLUMN content TEXT AFTER title;
+```
 
 ## 開發流程
 

--- a/src/controllers/caseController.ts
+++ b/src/controllers/caseController.ts
@@ -6,13 +6,15 @@ import { safeJsonParse } from '../utils/safeJsonParse';
 /** 建立新案例 */
 export const createCase = async (req: RequestWithUser, res: Response) => {
     try {
-        const { defendantName, defendantPhone, defendantIdNo } = req.body;
+        const { title, content, defendantName, defendantPhone, defendantIdNo } = req.body;
         const imageUrls = (
       req.files as Express.MulterS3.File[] | undefined
         )?.map((f) => `https://${f.bucket}.s3.amazonaws.com/${f.key}`) ?? [];
 
         const id = await caseService.createCase({
             plaintiffId: req.user!.uid,
+            title,
+            content,
             defendantName,
             defendantPhone,
             defendantIdNo,

--- a/src/services/caseService.ts
+++ b/src/services/caseService.ts
@@ -6,6 +6,8 @@ import { safeJsonParse } from '../utils/safeJsonParse';
  *********************************/
 export interface CreateCaseInput {
   plaintiffId: string;
+  title: string;
+  content: string;
   defendantName: string;
   defendantPhone: string;
   defendantIdNo: string;
@@ -15,6 +17,8 @@ export interface CreateCaseInput {
 export interface CaseRow {
   id: number;
   plaintiffId: string;
+  title: string;
+  content: string;
   defendantName: string;
   defendantPhone: string;
   defendantIdNo: string;
@@ -43,6 +47,8 @@ export interface CaseCommentRow {
 export const createCase = async (data: CreateCaseInput): Promise<number> => {
     const [id] = await db<CaseRow>('cases').insert({
         plaintiffId: data.plaintiffId,
+        title: data.title,
+        content: data.content,
         defendantName: data.defendantName,
         defendantPhone: data.defendantPhone,
         defendantIdNo: data.defendantIdNo,


### PR DESCRIPTION
## Summary
- document SQL to add `title` and `content` columns to the `cases` table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68515c023c94832da52ee0238dc4a823