### PR TITLE
Add IP to comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ ALTER TABLE cases
     ADD COLUMN district VARCHAR(20) NOT NULL AFTER location;
 ```
 
+若 `comments` 與 `caseComments` 表尚無 `ip` 欄位，可執行下列 SQL 新增：
+
+```sql
+ALTER TABLE comments ADD COLUMN ip VARCHAR(45) AFTER content;
+ALTER TABLE caseComments ADD COLUMN ip VARCHAR(45) AFTER content;
+```
+
 ## 開發流程
 
 -   sudo service mysql start

--- a/src/controllers/caseController.ts
+++ b/src/controllers/caseController.ts
@@ -59,8 +59,9 @@ export const addComment = async (req: RequestWithUser, res: Response) => {
     try {
         await caseService.addComment(
             Number(req.params.id),
-      req.user!.uid,
-      req.body.content
+            req.user!.uid,
+            req.body.content,
+            (req.headers['x-forwarded-for'] || req.socket.remoteAddress) as string
         );
         return res.status(201).end();
     } catch (err) {

--- a/src/controllers/commentController.ts
+++ b/src/controllers/commentController.ts
@@ -6,7 +6,8 @@ export default {
     async addComment(req: RequestWithUser, res: Response) {
         const userId = req.user!.uid;
         const { filesetId, content } = req.body;
-        const comment = await commentService.createComment(userId, filesetId, content);
+        const ip = (req.headers['x-forwarded-for'] || req.socket.remoteAddress) as string;
+        const comment = await commentService.createComment(userId, filesetId, content, ip);
         res.status(201).json(comment);
     },
 

--- a/src/repositories/commentRepository.ts
+++ b/src/repositories/commentRepository.ts
@@ -2,12 +2,13 @@ import { db } from '../db';
 import { Comment } from '../types/comment';          // 自訂型別
 
 export default {
-    async insert(userId: string, filesetId: string, content: string): Promise<Comment> {
+    async insert(userId: string, filesetId: string, content: string, ip: string): Promise<Comment> {
         // ① 插入並取得 insertId
         const [result] = await db('comments').insert({
             userId,
             filesetId,
             content,
+            ip,
         });
 
         const insertId = typeof result === 'number'
@@ -17,7 +18,7 @@ export default {
         // ② 取回含使用者資訊的完整列
         const created = await db<Comment>('comments as c')
             .join('users as u', 'c.userId', 'u.uid')
-            .select('c.*', 'u.name', 'u.email', 'u.phone', 'u.ip')
+            .select('c.*', 'u.name', 'u.email', 'u.phone')
             .where('c.id', insertId)
             .first();
 
@@ -28,7 +29,7 @@ export default {
     async findByFileset(filesetId: string): Promise<Comment[]> {
         return db<Comment>('comments as c')
             .join('users as u', 'c.userId', 'u.uid')
-            .select('c.*', 'u.name', 'u.email', 'u.phone', 'u.ip')
+            .select('c.*', 'u.name', 'u.email', 'u.phone')
             .where('c.filesetId', filesetId)
             .orderBy('c.createdAt', 'desc');
     },

--- a/src/services/caseService.ts
+++ b/src/services/caseService.ts
@@ -120,7 +120,7 @@ export const getCaseDetail = async (id: number) => {
     // 留言
     const comments = await db<CaseCommentRow>('caseComments as cc')
         .join('users as u', 'cc.userId', 'u.uid')
-        .select('cc.*', 'u.name', 'u.ip')
+        .select('cc.*', 'u.name')
         .where('cc.caseId', id)
         .orderBy('cc.createdAt');
 
@@ -140,9 +140,10 @@ export const getCaseDetail = async (id: number) => {
 export const addComment = async (
     caseId: number,
     userId: string,
-    content: string
+    content: string,
+    ip: string
 ): Promise<void> => {
-    await db('caseComments').insert({ caseId, userId, content });
+    await db('caseComments').insert({ caseId, userId, content, ip });
 };
 
 /** 按讚 / 取消按讚，回傳按讚後狀態 */

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -1,8 +1,8 @@
 import commentRepository from '../repositories/commentRepository';
 
 export default {
-    async createComment(userId: string, filesetId: string, content: string) {
-        return commentRepository.insert(userId, filesetId, content);
+    async createComment(userId: string, filesetId: string, content: string, ip: string) {
+        return commentRepository.insert(userId, filesetId, content, ip);
     },
 
     async getCommentsByFileset(filesetId: string) {

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -22,4 +22,6 @@ export interface Comment {
   name?: string;
   email?: string;
   phone?: string;
+  /** 使用者留言時的 IP */
+  ip?: string;
 }


### PR DESCRIPTION
## Summary
- collect request IP when posting comments on home and forum
- store comment IP in DB
- document SQL for new IP columns

## Testing
- `npm test`
- `npx tsc -p .` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_685797218b40832d949800c7c37f50b3