### PR TITLE
Implement IP column for cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ sudo apt install mysql-client mysql-server
             -   defendantPhone `string`
             -   defendantIdNo `string`
             -   imageUrls `text`
+            -   ip `string`
             -   createdAt `timestamp`
             -   updatedAt `timestamp`
 
@@ -94,6 +95,12 @@ ALTER TABLE cases
     ADD COLUMN content TEXT AFTER title,
     ADD COLUMN location VARCHAR(20) NOT NULL AFTER content,
     ADD COLUMN district VARCHAR(20) NOT NULL AFTER location;
+```
+
+若 `cases` 表尚無 `ip` 欄位，可執行下列 SQL 新增：
+
+```sql
+ALTER TABLE cases ADD COLUMN ip VARCHAR(45) AFTER imageUrls;
 ```
 
 若 `comments` 與 `caseComments` 表尚無 `ip` 欄位，可執行下列 SQL 新增：

--- a/src/controllers/caseController.ts
+++ b/src/controllers/caseController.ts
@@ -11,6 +11,7 @@ export const createCase = async (req: RequestWithUser, res: Response) => {
         const imageUrls = (
       req.files as Express.MulterS3.File[] | undefined
         )?.map((f) => `https://${f.bucket}.s3.amazonaws.com/${f.key}`) ?? [];
+        const ip = getClientIp(req);
 
         const id = await caseService.createCase({
             plaintiffId: req.user!.uid,
@@ -22,6 +23,7 @@ export const createCase = async (req: RequestWithUser, res: Response) => {
             defendantPhone,
             defendantIdNo,
             imageUrls,
+            ip,
         });
 
         return res.status(201).json({ id });

--- a/src/services/caseService.ts
+++ b/src/services/caseService.ts
@@ -13,6 +13,7 @@ export interface CreateCaseInput {
   defendantPhone: string;
   defendantIdNo: string;
   imageUrls: string[]; // S3 連結陣列
+  ip: string;
 }
 
 export interface CaseRow {
@@ -60,6 +61,7 @@ export const createCase = async (data: CreateCaseInput): Promise<number> => {
         defendantPhone: data.defendantPhone,
         defendantIdNo: data.defendantIdNo,
         imageUrls: JSON.stringify(data.imageUrls),
+        ip: data.ip,
     });
     return Number(id);
 };
@@ -84,7 +86,7 @@ export const listCases = async (): Promise<CaseRow[]> => {
             'u.name',
             'u.email',
             'u.phone',
-            'u.ip'
+            'c.ip'
         )
         .orderBy('c.createdAt', 'desc');
 
@@ -111,7 +113,7 @@ export const getCaseDetail = async (id: number) => {
             'u.name',
             'u.email',
             'u.phone',
-            'u.ip'
+            'c.ip'
         )
         .where('c.id', id)
         .first();


### PR DESCRIPTION
## Summary
- track user IP when creating cases
- store case IP information in DB and expose in listings
- document new IP column for cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857a6be40cc832dab27cb8d0e3f893d