### PR TITLE
Implement case search API

### DIFF
--- a/src/controllers/caseController.ts
+++ b/src/controllers/caseController.ts
@@ -103,3 +103,24 @@ export const getLikeStatus = async (
         return res.status(500).json({ message: 'getLikeStatus failed' });
     }
 };
+
+/** 依照被告姓名、電話與身分證字號搜尋案例 */
+export const searchCases = async (req: Request, res: Response) => {
+    try {
+        const { name, phone, idno } = req.query as {
+            name: string;
+            phone: string;
+            idno: string;
+        };
+
+        if (!name || !phone || !idno) {
+            return res.status(400).json({ message: 'missing parameter' });
+        }
+
+        const rows = await caseService.searchCases(name, phone, idno);
+        return res.json(rows);
+    } catch (err) {
+        console.error('searchCases error:', err);
+        return res.status(500).json({ message: 'searchCases failed' });
+    }
+};

--- a/src/routes/caseRoutes.ts
+++ b/src/routes/caseRoutes.ts
@@ -25,6 +25,7 @@ const router = Router();
 
 router.post('/', checkLoggedIn, upload.array('images', 10), caseCtrl.createCase);
 router.get('/', caseCtrl.listCases);
+router.get('/search', caseCtrl.searchCases);
 router.get('/:id', caseCtrl.getCaseDetail);
 router.post('/:id/comments', checkLoggedIn, caseCtrl.addComment);
 router.post('/:id/like', checkLoggedIn, caseCtrl.toggleLike);

--- a/src/services/caseService.ts
+++ b/src/services/caseService.ts
@@ -170,3 +170,38 @@ export const getLikeStatus = async (
     const liked = await db('caseLikes').where({ caseId, userId }).first();
     return Boolean(liked);
 };
+
+/** 依照被告姓名、電話與身分證字號精確搜尋案例 */
+export const searchCases = async (
+    name: string,
+    phone: string,
+    idNo: string
+): Promise<CaseRow[]> => {
+    const rows = await db<CaseRow>('cases as c')
+        .join('users as u', 'c.plaintiffId', 'u.uid')
+        .select(
+            'c.id',
+            'c.plaintiffId',
+            'c.title',
+            'c.content',
+            'c.location',
+            'c.district',
+            'c.defendantName',
+            'c.defendantPhone',
+            'c.defendantIdNo',
+            'c.imageUrls',
+            'c.createdAt',
+            'c.updatedAt',
+            'u.name',
+            'u.email',
+            'u.phone',
+            'c.ip'
+        )
+        .where({
+            'c.defendantName': name,
+            'c.defendantPhone': phone,
+            'c.defendantIdNo': idNo,
+        });
+
+    return rows;
+};


### PR DESCRIPTION
## Summary
- add precise case search in service layer
- expose `/case/search` API endpoint
- wire controller to handle name, phone, id number search
- fix parameter naming per feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685aac05bd78832db0df72c6af78023e