### PR TITLE
Return phone only for login response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,8 +89,8 @@ declare module 'express-session' {
                     uid,
                     phone,
                     ip,
-                    name, 
-                    email
+                    name,
+                    email,
                 };
                 const token = jwt.sign(userPayload, process.env.JWT_SECRET!, {
                     expiresIn: '1y', // 設定過期時間
@@ -100,7 +100,7 @@ declare module 'express-session' {
                     uid,
                     phone,
                     ip,
-                    name, 
+                    name,
                     email,
                     token,
                 });

--- a/src/repositories/commentRepository.ts
+++ b/src/repositories/commentRepository.ts
@@ -18,7 +18,7 @@ export default {
         // ② 取回含使用者資訊的完整列
         const created = await db<Comment>('comments as c')
             .join('users as u', 'c.userId', 'u.uid')
-            .select('c.*', 'u.name', 'u.email', 'u.phone')
+            .select('c.*', 'u.name', 'u.email')
             .where('c.id', insertId)
             .first();
 
@@ -29,7 +29,7 @@ export default {
     async findByFileset(filesetId: string): Promise<Comment[]> {
         return db<Comment>('comments as c')
             .join('users as u', 'c.userId', 'u.uid')
-            .select('c.*', 'u.name', 'u.email', 'u.phone')
+            .select('c.*', 'u.name', 'u.email')
             .where('c.filesetId', filesetId)
             .orderBy('c.createdAt', 'desc');
     },

--- a/src/services/caseService.ts
+++ b/src/services/caseService.ts
@@ -31,7 +31,6 @@ export interface CaseRow {
   updatedAt: Date;
   name?: string;
   email?: string;
-  phone?: string;
   ip?: string;
 }
 
@@ -85,7 +84,6 @@ export const listCases = async (): Promise<CaseRow[]> => {
             'c.updatedAt',
             'u.name',
             'u.email',
-            'u.phone',
             'c.ip'
         )
         .orderBy('c.createdAt', 'desc');
@@ -112,7 +110,6 @@ export const getCaseDetail = async (id: number) => {
             'c.updatedAt',
             'u.name',
             'u.email',
-            'u.phone',
             'c.ip'
         )
         .where('c.id', id)
@@ -190,7 +187,6 @@ export const searchCases = async (search: string): Promise<CaseRow[]> => {
             'c.updatedAt',
             'u.name',
             'u.email',
-            'u.phone',
             'c.ip'
         )
         .where('c.defendantName', search)

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -21,7 +21,6 @@ export interface Comment {
   /** 由 JOIN users 取得（可選） */
   name?: string;
   email?: string;
-  phone?: string;
   /** 使用者留言時的 IP */
   ip?: string;
 }


### PR DESCRIPTION
## Summary
- include phone number in the /verify login response
- keep phone hidden in other user responses
- revert unintended user controller changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b844534fc832d8da4739d3106d0a4