### PR TITLE
Implement user registration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ ALTER TABLE comments ADD COLUMN ip VARCHAR(45) AFTER content;
 ALTER TABLE caseComments ADD COLUMN ip VARCHAR(45) AFTER content;
 ```
 
+若 `users` 表尚無以下欄位，可執行下列 SQL 新增：
+
+```sql
+ALTER TABLE users
+    ADD COLUMN password VARCHAR(255) NOT NULL AFTER phone,
+    ADD COLUMN displayName VARCHAR(100) NOT NULL AFTER name;
+```
+
 應用程式會從 `X-Forwarded-For` HTTP 頭解析使用者真實 IP，若無此頭則退
 回連線位址。
 

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,7 +1,11 @@
 import { Request, Response } from 'express';
 import { RequestWithUser } from '../middlewares/checkLoggedIn';
 import updateUser from '../utils/updateUser';
-import {signJwt} from '../utils/jwt';
+import { signJwt } from '../utils/jwt';
+import { db } from '../db';
+import crypto from 'crypto';
+import hashPassword from '../utils/hashPassword';
+import firebaseApp from '../lib/firebase';
 
 export default {
     async getUser(req: RequestWithUser, res: Response) {
@@ -18,5 +22,69 @@ export default {
         const userPayload = {name, phone, email, uid, ip};
         const token = signJwt(userPayload);
         res.status(201).json({...userPayload, token});
+    }
+};
+
+export const register = async (req: Request, res: Response) => {
+    try {
+        const { token, password, name, displayName, email } = req.body as {
+            token?: string;
+            password?: string;
+            name?: string;
+            displayName?: string;
+            email?: string;
+        };
+
+        if (!token) {
+            return res.status(400).json({ message: 'missing token' });
+        }
+
+        const ip = (req.headers['x-forwarded-for'] || req.socket.remoteAddress) as string;
+
+        // 驗證簡訊 token
+        const decodedToken = await firebaseApp.auth().verifyIdToken(token);
+        const { uid, phone_number: phone } = decodedToken as { uid: string; phone_number?: string };
+
+        if (!uid || !phone) {
+            return res.status(401).json({ message: 'Invalid token' });
+        }
+
+        if (!password || password.length < 8) {
+            return res.status(400).json({ message: 'password must be at least 8 characters' });
+        }
+        if (!name || !displayName || !email) {
+            return res.status(400).json({ message: 'missing required fields' });
+        }
+
+        const existing = await db('users').where({ phone }).first();
+        if (existing && existing.password) {
+            return res.status(409).json({ message: 'phone already exists' });
+        }
+
+        const hashed = hashPassword(password);
+
+        if (existing) {
+            await db('users')
+                .where({ phone })
+                .update({ uid, ip, password: hashed, name, displayName, email });
+        } else {
+            await db('users').insert({
+                uid,
+                phone,
+                ip,
+                password: hashed,
+                name,
+                displayName,
+                email,
+            });
+        }
+
+        const userPayload = { uid, phone, ip, name, email };
+        const jwtToken = signJwt(userPayload);
+
+        return res.status(201).json({ uid, phone, name, displayName, email, token: jwtToken });
+    } catch (err) {
+        console.error('register error:', err);
+        return res.status(500).json({ message: 'register failed' });
     }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,11 @@
 import './env';
 import express, { Request, Response } from 'express';
 import cors from 'cors';
-import jwt from 'jsonwebtoken';
 
 import getCases from './utils/getCases';
 import getName from './utils/getName';
-import firebaseApp from './lib/firebase';
 import router from './routes';
-import { healthCheck, db } from './db';
+import { healthCheck } from './db';
 import errorHandler from './middlewares/errorHandler';
 
 declare module 'express-session' {
@@ -56,63 +54,6 @@ declare module 'express-session' {
         res.send(name);
     });
 
-    app.post('/verify', async (req: Request, res: Response) => {
-        const { token }: { token: string; phone: string } = req.body;
-        const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
-
-        try {
-            // 驗證簡訊 token
-            const decodedToken = await firebaseApp.auth().verifyIdToken(token);
-
-            // 如果驗證成功，將電話號碼存入到 MySQL
-            const { uid, phone_number: phone } = decodedToken;
-            if (uid) {
-                // 使用您的 knex 實例來存儲 phone
-                // 假設您已經有一個名為 "users" 的表格，並且有一個名為 "phone" 的列
-                await db.raw(
-                    `
-                INSERT INTO users (uid, ip, phone)
-                VALUES (?, ?, ?)
-                ON DUPLICATE KEY UPDATE 
-                ip = VALUES(ip),
-                phone = VALUES(phone)
-            `,
-                    [uid, ip, phone]
-                );
-                const {name, email} = await db('users')
-                    .select('name', 'email')
-                    .where({ uid })
-                    .first();
-            
-
-                const userPayload = {
-                    uid,
-                    phone,
-                    ip,
-                    name,
-                    email,
-                };
-                const token = jwt.sign(userPayload, process.env.JWT_SECRET!, {
-                    expiresIn: '1y', // 設定過期時間
-                });
-
-                res.status(200).send({
-                    uid,
-                    phone,
-                    ip,
-                    name,
-                    email,
-                    token,
-                });
-            } else {
-                res.status(401).send({ message: 'Invalid token.' });
-            }
-        } catch (error) {
-            console.error(error);
-            // 如果驗證失敗，返回錯誤信息
-            res.status(401).send({ message: 'Token verification failed.' });
-        }
-    });
     
     app.use(router);
 

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
-import userController from '../controllers/userController';
+import userController, { register } from '../controllers/userController';
 import checkLoggedIn from '../middlewares/checkLoggedIn';
 
 const router = Router();
 
+router.post('/register', register);
 router.get('/user', checkLoggedIn, userController.getUser);
 router.post('/user', checkLoggedIn, userController.createUser);
 

--- a/src/utils/hashPassword.ts
+++ b/src/utils/hashPassword.ts
@@ -1,0 +1,5 @@
+import { createHash } from 'crypto';
+
+export default function hashPassword(password: string): string {
+    return createHash('sha256').update(password).digest('hex');
+}


### PR DESCRIPTION
## Summary
- add SQL instructions for new user fields
- add SHA256-based password hashing utility
- implement registration controller and route
- wire auth routes into the router
- adjust registration to use phone number as the account
- consolidate routes by moving registration into `userRoutes`
- migrate registration handler into userController
- combine phone verification with registration

## Testing
- `npm test`
- `npx tsc -p tsconfig.json` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6861f29d84d4832da22961052e4c6386