### PR TITLE
Implement paginated case listing

### DIFF
--- a/src/controllers/caseController.ts
+++ b/src/controllers/caseController.ts
@@ -52,9 +52,12 @@ export const createCase = async (req: RequestWithUser, res: Response) => {
 };
 
 /** 案例列表 */
-export const listCases = async (_req: Request, res: Response) => {
+export const listCases = async (req: Request, res: Response) => {
     try {
-        const rows = await caseService.listCases();
+        const { page } = req.query as { page?: string };
+        let pageNum = page ? parseInt(page, 10) : 1;
+        if (Number.isNaN(pageNum) || pageNum < 1) pageNum = 1;
+        const rows = await caseService.listCases(pageNum);
         const masked = rows.map((r) => ({
             ...r,
             defendantName: maskHalf(r.defendantName),

--- a/src/services/caseService.ts
+++ b/src/services/caseService.ts
@@ -69,7 +69,11 @@ export const createCase = async (data: CreateCaseInput): Promise<number> => {
 };
 
 /** 取案例列表（依建立時間倒序） */
-export const listCases = async (): Promise<CaseRow[]> => {
+export const listCases = async (
+    page = 1,
+    pageSize = 10
+): Promise<CaseRow[]> => {
+    const offset = (page - 1) * pageSize;
     const rows = await db<CaseRow>('cases as c')
         .join('users as u', 'c.plaintiffId', 'u.uid')
         .select(
@@ -90,7 +94,9 @@ export const listCases = async (): Promise<CaseRow[]> => {
             'u.email',
             'c.ip'
         )
-        .orderBy('c.createdAt', 'desc');
+        .orderBy('c.createdAt', 'desc')
+        .limit(pageSize)
+        .offset(offset);
 
     return rows;
 };


### PR DESCRIPTION
## Summary
- add paging support in `listCases` service
- parse `page` query param in `listCases` controller

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6870b997be30832db690068409ec681b