### PR TITLE
Add total pages endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@
         -   案件 ID
         -   年份
 
+`GET /case` 可透過 query `page` 指定頁碼、`pageSize` 指定單頁
+筆數（預設 10）。
+
+新增 `GET /case/pages` API，可透過 query `pageSize` 指定單頁筆數
+（預設 10），回傳 `totalPages` 欄位，此值會以案件總數除以
+`pageSize` 計算並取整數上限，方便前端判斷頁面總數。
+
 ## 安裝 Mysql
 
 -   安裝指令

--- a/src/controllers/caseController.ts
+++ b/src/controllers/caseController.ts
@@ -54,10 +54,18 @@ export const createCase = async (req: RequestWithUser, res: Response) => {
 /** 案例列表 */
 export const listCases = async (req: Request, res: Response) => {
     try {
-        const { page } = req.query as { page?: string };
+        const { page, pageSize } = req.query as {
+            page?: string;
+            pageSize?: string;
+        };
+
         let pageNum = page ? parseInt(page, 10) : 1;
         if (Number.isNaN(pageNum) || pageNum < 1) pageNum = 1;
-        const rows = await caseService.listCases(pageNum);
+
+        let size = pageSize ? parseInt(pageSize, 10) : 10;
+        if (Number.isNaN(size) || size < 1) size = 10;
+
+        const rows = await caseService.listCases(pageNum, size);
         const masked = rows.map((r) => ({
             ...r,
             defendantName: maskHalf(r.defendantName),
@@ -68,6 +76,22 @@ export const listCases = async (req: Request, res: Response) => {
     } catch (err) {
         console.error('listCases error:', err);
         return res.status(500).json({ message: 'listCases failed' });
+    }
+};
+
+/** 取得案例總頁數 */
+export const getTotalPages = async (req: Request, res: Response) => {
+    try {
+        const { pageSize } = req.query as { pageSize?: string };
+        let size = pageSize ? parseInt(pageSize, 10) : 10;
+        if (Number.isNaN(size) || size < 1) size = 10;
+
+        const totalCount = await caseService.countCases();
+        const totalPages = Math.ceil(totalCount / size);
+        return res.json({ totalPages });
+    } catch (err) {
+        console.error('getTotalPages error:', err);
+        return res.status(500).json({ message: 'getTotalPages failed' });
     }
 };
 

--- a/src/routes/caseRoutes.ts
+++ b/src/routes/caseRoutes.ts
@@ -25,6 +25,7 @@ const router = Router();
 
 router.post('/', checkLoggedIn, upload.array('images', 10), caseCtrl.createCase);
 router.get('/', caseCtrl.listCases);
+router.get('/pages', caseCtrl.getTotalPages);
 router.get('/search/:search', checkLoggedIn, caseCtrl.searchCases);
 router.get('/:id', caseCtrl.getCaseDetail);
 router.post('/:id/comments', checkLoggedIn, caseCtrl.addComment);

--- a/src/services/caseService.ts
+++ b/src/services/caseService.ts
@@ -101,6 +101,12 @@ export const listCases = async (
     return rows;
 };
 
+/** 計算案例總數 */
+export const countCases = async (): Promise<number> => {
+    const [{ count }] = await db('cases').count('* as count');
+    return Number(count || 0);
+};
+
 /** 取單一案例詳情，包含留言與按讚數 */
 export const getCaseDetail = async (id: number) => {
     const caseRow = await db<CaseRow>('cases as c')


### PR DESCRIPTION
## Summary
- allow passing `pageSize` to `GET /case` and `GET /case/pages`
- document optional `pageSize` query parameter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870c2361f90832d9ee77c8e97cb4be3